### PR TITLE
Parameters for files filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,14 @@ i18n.init({
 //e.g. translation namespace
 i18n.t("translation:key");
 ```
+
+You can filter files in Filestructure using include and exclude parameters
+``` javascript
+var resBundle = require("i18next-resource-store-loader?include=\\.json$!../assets/i18n/index.js");
+// will load files with json extension only
+
+var resBundle = require("i18next-resource-store-loader?exclude=\\.json$!../assets/i18n/index.js");
+// will skip files with json extension
+```
+
 And your done. The index.js can be empty, its just needed to point the loader to the locales root directory.

--- a/index.js
+++ b/index.js
@@ -4,8 +4,22 @@
 */
 var path = require("path");
 var fs = require("fs");
+
+var loaderUtils = require('loader-utils');
+
 module.exports = function (indexContent) {
     this.cacheable && this.cacheable();
+
+    var options = loaderUtils.parseQuery(this.query);
+
+    var include;
+    if (options.include) {
+        include = new RegExp(options.include);
+    }
+    var exclude;
+    if (options.exclude) {
+        exclude = new RegExp(options.exclude);
+    }
 
     var baseDirectory = path.dirname(this.resource);
     var subdirs = fs.readdirSync(baseDirectory).filter(function (file) {
@@ -21,7 +35,9 @@ module.exports = function (indexContent) {
         resBundle[dirname] = {};
         //get sub files
         files = fs.readdirSync(path.join(baseDirectory, dirname)).filter(function (file) {
-            return fs.statSync(path.join(baseDirectory, dirname, file)).isFile();
+            return fs.statSync(path.join(baseDirectory, dirname, file)).isFile()
+                && (!include || include.test(file))
+                && (!(exclude && exclude.test(file)));
         });
         var filename, extname, basename, content, pathstring;
         for (var j = 0, len2 = files.length; j < len2; j++) {

--- a/package.json
+++ b/package.json
@@ -27,15 +27,18 @@
       "name": "Robert Krüger",
       "email": "robert@atroo.de"
     },
-      {
+    {
       "name": "Martin Foerster",
       "email": "martin@atroo.de"
     }
   ],
+  "dependencies": {
+      "loader-utils": "^0.2.11"
+  },
   "devDependencies": {
+    "chai": "^1.9.2",
     "gulp": "^3.8.10",
     "gulp-mocha": "^1.1.1",
-    "gulp-util": "^3.0.1",
-    "chai": "^1.9.2"
+    "gulp-util": "^3.0.1"
   }
 }

--- a/test/data/i18n/de/main.nonjson
+++ b/test/data/i18n/de/main.nonjson
@@ -1,0 +1,3 @@
+{
+    "test": "Das ist ein Test!"
+}

--- a/test/suites/basicTest.js
+++ b/test/suites/basicTest.js
@@ -52,4 +52,22 @@ describe("i18next loader basic testing", function () {
         expect(resStore.fr.main.test).to.be.a('string');
         expect(resStore.fr.main.test).to.be.equal('Ceci est un test!');
     });
+
+    it("should process files that satisfy regular expression from include parameter", function () {
+        thisScope.query = '?include=\\.json$';
+        thisScope.addDependency = function(path) {
+            expect(path).to.not.contain('main.nonjson');
+        };
+
+        var res = loader.call(thisScope, "index.js");
+    });
+
+    it("should not process files that satisfy regular expression from exclude parameter", function () {
+        thisScope.query = '?exclude=\\.nonjson$';
+        thisScope.addDependency = function(path) {
+            expect(path).to.not.contain('main.nonjson');
+        };
+
+        var res = loader.call(thisScope, "index.js");
+    });
 });


### PR DESCRIPTION
Hello!

In our project one of our developers faced a problem using vim text editor to edit resource files.
When you edit a file vim creates utility files in same directory. 
i18next-resource-store-loader loader can't differ these utility files from resource files and fail to load resources.

This PR fixes this problem by introducing two parameters:
- **include** [_regexp string_] - file will be loaded if it's name satisfy regexp;
- **exclude** [_regexp string_] - file won't be loaded if it's name satisfy regexp.
