### PR TITLE
Update example to work with i18next v2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,17 @@ Use the loader in the following way:
 
 ```javascript
 // File: main.js
-var i18n = require("i18next-client");
+var i18n = require("i18next");
 var resBundle = require(
   "i18next-resource-store-loader!../assets/i18n/index.js"
 );
 
 i18n.init({
-  resStore: resBundle
+  resources: resBundle
 });
 
 // Use the resources as documented on i18next.com
-// e.g. 'translation' namespace
-i18n.t("translation:key");
+i18n.t("key");
 ```
 
 You can filter files in your file structure using include and exclude parameters:


### PR DESCRIPTION
Hi, the current example in Readme does not work with i18next v2.x
Updated to:
- Require i18next directly, instead of i18next-client which is no longer needed
- Change `init` property from `resBundle` to `resources`
- Remove `translation:` prefix in t call.
