### PR TITLE
Update loader-utils to address security vulnerabilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ var path = require("path");
 var fs = require("fs");
 var _ = require("lodash");
 
-var loaderUtils = require('loader-utils');
-
 module.exports = function (indexContent) {
 	this.cacheable && this.cacheable();
 

--- a/index.js
+++ b/index.js
@@ -11,25 +11,25 @@ var loaderUtils = require('loader-utils');
 module.exports = function (indexContent) {
 	this.cacheable && this.cacheable();
 
-	var options = loaderUtils.parseQuery(this.query);
+	var options = new URLSearchParams(this.query);
 
 	var include;
-	if (options.include) {
-		include = new RegExp(options.include);
+	if (options.has('include')) {
+		include = new RegExp(options.get('include'));
 	}
 	var exclude;
-	if (options.exclude) {
-		exclude = new RegExp(options.exclude);
+	if (options.has('exclude')) {
+		exclude = new RegExp(options.get('exclude'));
 	}
 
 	var baseDirectory = path.dirname(this.resource);
 	var overrideDirectory, overrideBaseDirectory, inOverrideMode = false;
-	if (options.overrideDir) {
-		if (!options.baseDir) {
+	if (options.has('overrideDir')) {
+		if (!options.has('baseDir')) {
 			throw ("overrideDir can not be used without configuring a base dir");
 		}
-		overrideDirectory = path.join(baseDirectory, options.overrideDir);
-		overrideBaseDirectory = path.join(baseDirectory, options.baseDir);
+		overrideDirectory = path.join(baseDirectory, options.get('overrideDir'));
+		overrideBaseDirectory = path.join(baseDirectory, options.get('baseDir'));
 		inOverrideMode = true;
 	}
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     }
   ],
   "dependencies": {
-    "loader-utils": "^0.2.11",
+    "loader-utils": "^3.2.1",
     "lodash": "^4.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     }
   ],
   "dependencies": {
-    "loader-utils": "^3.2.1",
     "lodash": "^4.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The current version of `i18next-resource-store-loader` is using the `loader-utils`  version `0.2.11`.
This version has several security vulnerabilities.
https://github.com/webpack/loader-utils/issues/214
https://nvd.nist.gov/vuln/detail/CVE-2022-37599
https://nvd.nist.gov/vuln/detail/CVE-2022-37601
https://nvd.nist.gov/vuln/detail/CVE-2022-37603

So using `i18next-resource-store-loader` in a project leads to several vulnerabilities being reported by third part vulnerability analyzers since it is linking to a vulnerable version of the `loader-utils` library.

Seems that this project is using `loader-utils` for `parseQuery` function only, which has been removed from version 3.0 of `loader-utils`.
Reference: https://github.com/webpack/loader-utils/blob/master/CHANGELOG.md
`removed parseQuery in favor new URLSearchParams(loaderContext.resourceQuery.slice(1)) where loaderContext is this in loader function`

As part of this PR, loader-utils library dependency has been removed and calls to `parseQuery` have been replaced with `URLSearchParams`.

Ran the unit tests which passed after the changes
```
 gulp test
[06:15:24] Using gulpfile /work/i18next-resource-store-loader/gulpfile.js
[06:15:24] Starting 'test'...
 12  -_-_-_-_-_-_-_,------,
 0   -_-_-_-_-_-_-_|   /\_/\
 0   -_-_-_-_-_-_-^|__( ^ .^)
     -_-_-_-_-_-_-  ""  ""

  12 passing (23ms)

[06:15:24] Finished 'test' after 65 ms
```